### PR TITLE
added API to subscribe to new finalized block heads with a callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "JavaScript library to interact with InterBTC",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/src/external/electrs.ts
+++ b/src/external/electrs.ts
@@ -22,6 +22,7 @@ import { btcToSat } from "../utils/currency";
 export type TxStatus = {
     confirmed: boolean;
     confirmations: number;
+    blockHeight?: number;
 };
 
 export type TxOutput = {
@@ -65,7 +66,8 @@ export interface ElectrsAPI {
     getMerkleProof(txid: string): Promise<string>;
     /**
      * @param txid The ID of a Bitcoin transaction
-     * @returns A TxStatus object, containing the confirmation status and number of confirmations
+     * @returns A TxStatus object, containing the confirmation status and number of confirmations, plus block height if
+     * the tx is included in the blockchain
      */
     getTransactionStatus(txid: string): Promise<TxStatus>;
     /**
@@ -324,7 +326,7 @@ export class DefaultElectrsAPI implements ElectrsAPI {
     }
 
     async getTransactionStatus(txid: string): Promise<TxStatus> {
-        const status = {
+        const status:TxStatus = {
             confirmed: false,
             confirmations: 0,
         };
@@ -337,6 +339,7 @@ export class DefaultElectrsAPI implements ElectrsAPI {
         if (txStatus.block_height && latest_block_height - txStatus.block_height >= 0) {
             // use Bitoin Core definition of confirmations (= block depth)
             status.confirmations = latest_block_height - txStatus.block_height + 1;
+            status.blockHeight = txStatus.block_height;
             // note that block_height will only be set if confirmed == true, i.e. block
             // depth is at least 1. So confirmations 0 will only be returned while unconfirmed.
             // This is correct.

--- a/src/parachain/system.ts
+++ b/src/parachain/system.ts
@@ -15,7 +15,7 @@ export interface SystemAPI {
     getCurrentActiveBlockNumber(): Promise<number>;
 
     /**
-     * On every new parachain block, call the callback function with the ID of the expired request.
+     * On every new parachain block, call the callback function with the new block header
      * @param callback Function to be called with every new block header
      */
     subscribeToNewBlockHeads(callback: (blockHeader: Header) => void): Promise<() => void>;


### PR DESCRIPTION
Stats/Index needs to subscribe to the latest parachain block number. I exposed a subscription to the entire header in case it becomes useful elsewhere.

Additionally, adds `block_height` return to `getTransactionStatus()`, to optimise away the extra call to `getTransactionBlockHeight` in cases where both the status and the block height are necessary.