### PR TITLE
refactor: reduce number of calls and parallelize to get system capacity

### DIFF
--- a/src/parachain/tokens.ts
+++ b/src/parachain/tokens.ts
@@ -54,21 +54,18 @@ export class DefaultTokensAPI extends DefaultTransactionAPI implements TokensAPI
         const head = await this.api.rpc.chain.getFinalizedHead();
         const encodedCurrency = encodeCurrencyIdLiteral(this.api, currency);
         const totalBN = await this.api.query.tokens.totalIssuance.at(head, encodedCurrency);
-        // FIXME: should convert based on currency Id
         return satToBTC(totalBN);
     }
 
     async balance(currency: CurrencyIdLiteral, id: AccountId): Promise<Big> {
         const encodedCurrency = encodeCurrencyIdLiteral(this.api, currency);
         const account = await this.api.query.tokens.accounts(id, encodedCurrency);
-        // FIXME: should convert based on currency Id
         return satToBTC(account.free);
     }
 
     async balanceLocked(currency: CurrencyIdLiteral, id: AccountId): Promise<Big> {
         const encodedCurrency = encodeCurrencyIdLiteral(this.api, currency);
         const account = await this.api.query.tokens.accounts(id, encodedCurrency);
-        // FIXME: should convert based on currency Id
         return satToBTC(account.reserved);
     }
 
@@ -94,7 +91,6 @@ export class DefaultTokensAPI extends DefaultTransactionAPI implements TokensAPI
     }
 
     async transfer(currency: CurrencyIdLiteral, destination: string, amount: Big): Promise<void> {
-        // FIXME: should convert based on currency Id
         const amountSmallDenomination = this.api.createType("Balance", btcToSat(amount));
         const encodedCurrency = encodeCurrencyIdLiteral(this.api, currency);
         const transferTransaction = this.api.tx.tokens.transfer(destination, encodedCurrency, amountSmallDenomination);

--- a/src/parachain/tokens.ts
+++ b/src/parachain/tokens.ts
@@ -54,18 +54,21 @@ export class DefaultTokensAPI extends DefaultTransactionAPI implements TokensAPI
         const head = await this.api.rpc.chain.getFinalizedHead();
         const encodedCurrency = encodeCurrencyIdLiteral(this.api, currency);
         const totalBN = await this.api.query.tokens.totalIssuance.at(head, encodedCurrency);
+        // FIXME: should convert based on currency Id
         return satToBTC(totalBN);
     }
 
     async balance(currency: CurrencyIdLiteral, id: AccountId): Promise<Big> {
         const encodedCurrency = encodeCurrencyIdLiteral(this.api, currency);
         const account = await this.api.query.tokens.accounts(id, encodedCurrency);
+        // FIXME: should convert based on currency Id
         return satToBTC(account.free);
     }
 
     async balanceLocked(currency: CurrencyIdLiteral, id: AccountId): Promise<Big> {
         const encodedCurrency = encodeCurrencyIdLiteral(this.api, currency);
         const account = await this.api.query.tokens.accounts(id, encodedCurrency);
+        // FIXME: should convert based on currency Id
         return satToBTC(account.reserved);
     }
 
@@ -91,6 +94,7 @@ export class DefaultTokensAPI extends DefaultTransactionAPI implements TokensAPI
     }
 
     async transfer(currency: CurrencyIdLiteral, destination: string, amount: Big): Promise<void> {
+        // FIXME: should convert based on currency Id
         const amountSmallDenomination = this.api.createType("Balance", btcToSat(amount));
         const encodedCurrency = encodeCurrencyIdLiteral(this.api, currency);
         const transferTransaction = this.api.tx.tokens.transfer(destination, encodedCurrency, amountSmallDenomination);

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -564,7 +564,7 @@ export class DefaultVaultsAPI extends DefaultTransactionAPI implements VaultsAPI
         const [interBtcCapacity, issuedAmountBtc] = await Promise.all([
             this.calculateCapacity(totalLockedDot),
             this.getTotalIssuedAmount()
-        ])
+        ]);
         return interBtcCapacity.sub(issuedAmountBtc);
     }
 
@@ -573,7 +573,7 @@ export class DefaultVaultsAPI extends DefaultTransactionAPI implements VaultsAPI
         const [exchangeRate, secureCollateralThreshold] = await Promise.all([
             oracle.getExchangeRate(),
             this.getSecureCollateralThreshold()
-        ])
+        ]);
         return collateral.div(exchangeRate).div(secureCollateralThreshold);
     }
 


### PR DESCRIPTION
Refactored:
- The current way to get the system capacity would get the issued tokens for every vault. However, this is the same as the total supply of interBTC. Therefore, it's easier to just get the total of interBTC.
- The backing collateral in DOT is already contained in the vault struct, removed that extra call to get the vault twice from the chain.
- Executed some calls in parallel instead of sequentially. 