### PR TITLE
fix: Nomination rewards; remove non-interbtc fee getters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "description": "JavaScript library to interact with InterBTC",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/src/external/interbtc-index.ts
+++ b/src/external/interbtc-index.ts
@@ -7,7 +7,6 @@ type GeneratedMiddlewareFns = typeof GeneratedMiddlewareFns[number];
 // has a 'fooRaw() => <Promise<ApiResponse<T>>' counterpart. These must be filtered out
 type RawApiResponse = Promise<interbtcIndex.ApiResponse<any>>;
 
-
 export type IndexAPI = Pick<
     interbtcIndex.IndexApi,
     {

--- a/src/interbtc-api.ts
+++ b/src/interbtc-api.ts
@@ -104,7 +104,7 @@ export class DefaultInterBTCAPI implements InterBTCAPI {
         this.redeem = new DefaultRedeemAPI(api, btcNetwork, this.electrsAPI, _account);
         this.nomination = new DefaultNominationAPI(api, btcNetwork, this.electrsAPI, _account);
         this.index = DefaultIndexAPI(new IndexConfiguration({ basePath: indexEndpoint }));
-        this.pools = new DefaultPoolsAPI(api);
+        this.pools = new DefaultPoolsAPI(api, btcNetwork, this.electrsAPI);
     }
 
     setAccount(account: AddressOrPair, signer?: Signer): void {

--- a/src/parachain/fee.ts
+++ b/src/parachain/fee.ts
@@ -40,7 +40,6 @@ export interface FeeAPI {
      */
     calculateAPY(
         feesWrapped: BTCAmount,
-        feesCollateral: PolkadotAmount,
         lockedCollateral: PolkadotAmount,
         exchangeRate?: ExchangeRate<Bitcoin, BTCUnit, Polkadot, PolkadotUnit>
     ): Promise<Big>;
@@ -94,7 +93,6 @@ export class DefaultFeeAPI implements FeeAPI {
 
     async calculateAPY<C extends CollateralUnit>(
         feesWrapped: BTCAmount,
-        feesCollateral: MonetaryAmount<Currency<C>, C>,
         lockedCollateral: MonetaryAmount<Currency<C>, C>,
         exchangeRate?: ExchangeRate<Bitcoin, BTCUnit, Currency<C>, C>
     ): Promise<Big> {
@@ -102,13 +100,12 @@ export class DefaultFeeAPI implements FeeAPI {
             return new Big(0);
         }
         if (exchangeRate === undefined) {
-            exchangeRate = await this.oracleAPI.getExchangeRate(feesCollateral.currency);
+            exchangeRate = await this.oracleAPI.getExchangeRate(lockedCollateral.currency);
         }
 
-        const feesWrappedAsCollateral = exchangeRate.toCounter(feesWrapped);
-        const totalFees = feesCollateral.add(feesWrappedAsCollateral).toBig();
+        const feesWrappedAsCollateral = exchangeRate.toCounter(feesWrapped).toBig();
 
         // convert to percentage
-        return totalFees.div(lockedCollateral.toBig()).mul(100);
+        return feesWrappedAsCollateral.div(lockedCollateral.toBig()).mul(100);
     }
 }

--- a/src/parachain/index.ts
+++ b/src/parachain/index.ts
@@ -10,5 +10,6 @@ export { SystemAPI, DefaultSystemAPI } from "./system";
 export { ConstantsAPI, DefaultConstantsAPI } from "./constants";
 export { ReplaceAPI, DefaultReplaceAPI } from "./replace";
 export { FeeAPI, DefaultFeeAPI } from "./fee";
+export { PoolsAPI, DefaultPoolsAPI } from "./pools";
 export { NominationAPI, DefaultNominationAPI } from "./nomination";
 export * from "./transaction";

--- a/src/parachain/redeem.ts
+++ b/src/parachain/redeem.ts
@@ -6,17 +6,23 @@ import { Bytes } from "@polkadot/types";
 import { Network } from "bitcoinjs-lib";
 import Big from "big.js";
 import BN from "bn.js";
-import { Bitcoin, BTCAmount, BTCUnit, ExchangeRate, Polkadot, PolkadotAmount, PolkadotUnit } from "@interlay/monetary-js";
+import {
+    Bitcoin,
+    BTCAmount,
+    BTCUnit,
+    ExchangeRate,
+    Polkadot,
+    PolkadotAmount,
+    PolkadotUnit,
+} from "@interlay/monetary-js";
 
 import { VaultsAPI, DefaultVaultsAPI } from "./vaults";
 import {
     decodeBtcAddress,
     decodeFixedPointType,
-    satToBTC,
     getTxProof,
     stripHexPrefix,
     encodeBtcAddress,
-    planckToDOT,
     storageKeyToNthInner,
     newAccountId,
     ensureHashEncoded,

--- a/src/parachain/vaults.ts
+++ b/src/parachain/vaults.ts
@@ -278,7 +278,7 @@ export class DefaultVaultsAPI extends DefaultTransactionAPI implements VaultsAPI
         this.tokensAPI = new DefaultTokensAPI(api);
         this.oracleAPI = new DefaultOracleAPI(api);
         this.feeAPI = new DefaultFeeAPI(api);
-        this.poolsAPI = new DefaultPoolsAPI(api);
+        this.poolsAPI = new DefaultPoolsAPI(api, btcNetwork, electrsAPI);
     }
 
     async register(planckCollateral: BN, publicKey: string): Promise<void> {
@@ -610,12 +610,11 @@ export class DefaultVaultsAPI extends DefaultTransactionAPI implements VaultsAPI
 
     async getAPY(vaultId: AccountId): Promise<Big> {
         // TODO: Fetch data for all collateral currencies
-        const [feesWrapped, feesCollateral, lockedCollateral] = await Promise.all([
-            await this.poolsAPI.getFeesWrapped(vaultId.toString()),
-            await this.poolsAPI.getFeesCollateral(vaultId.toString(), Polkadot),
+        const [feesWrapped, lockedCollateral] = await Promise.all([
+            await this.poolsAPI.getFeesWrapped(vaultId.toString(), Polkadot),
             await this.tokensAPI.balanceLocked(Polkadot, vaultId),
         ]);
-        return this.feeAPI.calculateAPY(feesWrapped, feesCollateral, lockedCollateral);
+        return this.feeAPI.calculateAPY(feesWrapped, lockedCollateral);
     }
 
     async getSLA(vaultId: AccountId): Promise<number> {

--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -6,11 +6,10 @@ import { Network } from "bitcoinjs-lib";
 import { StorageKey } from "@polkadot/types/primitive/StorageKey";
 import { Codec } from "@polkadot/types/types";
 import { BTCAmount, PolkadotAmount } from "@interlay/monetary-js";
-import * as interbtcIndex from "@interlay/interbtc-index-client";
 
 import { encodeBtcAddress, FIXEDI128_SCALING_FACTOR } from ".";
-import { WalletExt, SystemVaultExt, ParsedVaultData } from "../types/vault";
-import { Issue, IssueStatus, RefundRequestExt, ReplaceRequestExt } from "../types/requestTypes";
+import { WalletExt, SystemVaultExt } from "../types/vault";
+import { RefundRequestExt, ReplaceRequestExt } from "../types/requestTypes";
 import {
     SignedFixedPoint,
     UnsignedFixedPoint,
@@ -19,7 +18,6 @@ import {
     Wallet,
     RefundRequest,
     ReplaceRequest,
-    IssueRequest,
 } from "../interfaces";
 
 /**

--- a/test/integration/parachain/staging/fee.test.ts
+++ b/test/integration/parachain/staging/fee.test.ts
@@ -10,13 +10,11 @@ describe("fee", () => {
     let api: ApiPromise;
     let feeAPI: FeeAPI;
     let keyring: Keyring;
-    let alice: KeyringPair;
 
     before(async function () {
         api = await createPolkadotAPI(DEFAULT_PARACHAIN_ENDPOINT);
         keyring = new Keyring({ type: "sr25519" });
         feeAPI = new DefaultFeeAPI(api);
-        alice = keyring.addFromUri("//Alice");
     });
 
     after(async () => {

--- a/test/integration/parachain/staging/redeem.test.ts
+++ b/test/integration/parachain/staging/redeem.test.ts
@@ -36,7 +36,6 @@ describe("redeem", () => {
     // alice is the root account
     let alice: KeyringPair;
     let alice_stash: KeyringPair;
-    let charlie_stash: KeyringPair;
     const randomBtcAddress = "bcrt1qujs29q4gkyn2uj6y570xl460p4y43ruayxu8ry";
     let electrsAPI: ElectrsAPI;
     let bitcoinCoreClient: BitcoinCoreClient;
@@ -46,7 +45,6 @@ describe("redeem", () => {
         keyring = new Keyring({ type: "sr25519" });
         alice = keyring.addFromUri("//Alice");
         alice_stash = keyring.addFromUri("//Alice//stash");
-        charlie_stash = keyring.addFromUri("//Charlie//stash");
         electrsAPI = new DefaultElectrsAPI(REGTEST_ESPLORA_BASE_PATH);
         issueAPI = new DefaultIssueAPI(api, bitcoinjs.networks.regtest, electrsAPI);
         redeemAPI = new DefaultRedeemAPI(api, bitcoinjs.networks.regtest, electrsAPI);

--- a/test/integration/parachain/staging/staked-relayer.test.ts
+++ b/test/integration/parachain/staging/staked-relayer.test.ts
@@ -11,13 +11,11 @@ describe("stakedRelayerAPI", () => {
     let api: ApiPromise;
     let stakedRelayerAPI: StakedRelayerAPI;
     let keyring: Keyring;
-    let alice_stash: KeyringPair;
     let electrsAPI: ElectrsAPI;
 
     before(async () => {
         api = await createPolkadotAPI(DEFAULT_PARACHAIN_ENDPOINT);
         keyring = new Keyring({ type: "sr25519" });
-        alice_stash = keyring.addFromUri("//Alice//stash");
         electrsAPI = new DefaultElectrsAPI(REGTEST_ESPLORA_BASE_PATH);
         stakedRelayerAPI = new DefaultStakedRelayerAPI(api, bitcoinjs.networks.regtest, electrsAPI);
     });

--- a/test/integration/parachain/staging/vaults.test.ts
+++ b/test/integration/parachain/staging/vaults.test.ts
@@ -39,7 +39,7 @@ describe("vaultsAPI", () => {
         ferdie = keyring.addFromUri("//Ferdie");
         // Bob is the authorized oracle
         oracleAPI = new DefaultOracleAPI(api, bob);
-        poolsAPI = new DefaultPoolsAPI(api);
+        poolsAPI = new DefaultPoolsAPI(api, bitcoinjs.networks.regtest, electrsAPI);
         
         electrsAPI = new DefaultElectrsAPI(REGTEST_ESPLORA_BASE_PATH);
         vaultsAPI = new DefaultVaultsAPI(api, bitcoinjs.networks.regtest, electrsAPI);
@@ -239,10 +239,8 @@ describe("vaultsAPI", () => {
     });
 
     it("should getFees", async () => {
-        const feesWrapped = await poolsAPI.getFeesWrapped(charlie_stash.address);
-        const feesDOT = await poolsAPI.getFeesCollateral(charlie_stash.address, Polkadot);
+        const feesWrapped = await poolsAPI.getFeesWrapped(charlie_stash.address, Polkadot);
         assert.isTrue(feesWrapped.gte(BTCAmount.zero));
-        assert.isTrue(feesDOT.gte(PolkadotAmount.zero));
     });
 
     it("should getAPY", async () => {


### PR DESCRIPTION
The bug was on the lib side. Rewards in the `rewards` (global) pool were not scaled down by the nominator's proportion of collateral.

The PR also removes DOT rewards from APY calculation, since these will always be zero.