### PR TITLE
fix(package.json): fixed build paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@interlay/interbtc",
   "version": "0.21.2",
   "description": "JavaScript library to interact with InterBTC",
-  "main": "build/index.js",
-  "typings": "build/index.d.ts",
+  "main": "build/src/index.js",
+  "typings": "build/src/index.d.ts",
   "repository": "https://github.com/interlay/interbtc-js",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
Importing the lib fails for me without this (please double-check this change isn't only on my end - but I'm very consistently getting output in `build/src/*` in the latest lib version).