### PR TITLE
chore: Dedup @polkadot/util

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@interlay/monetary-js": "0.2.1",
     "@polkadot/api": "5.3.2",
     "@polkadot/keyring": "6.6.2-6",
-    "@polkadot/typegen": "5.3.2",
     "@types/big.js": "6.1.1",
     "big.js": "6.1.1",
     "bitcoin-core": "^3.0.0",
@@ -57,7 +56,7 @@
     "ts-mock-imports": "^1.3.0"
   },
   "devDependencies": {
-    "@polkadot/util": "^6.3.1",
+    "@polkadot/typegen": "5.3.2",
     "@types/chai": "^4.2.12",
     "@types/chai-as-promised": "^7.1.3",
     "@types/mocha": "^8.0.3",


### PR DESCRIPTION
Fixes this compilation warning:
```
$ ts-node --skip-project node_modules/.bin/polkadot-types-from-chain --package @interlay/interbtc/interfaces --endpoint ./src/json/parachain.json --output ./src/interfaces
@polkadot/util has multiple versions, ensure that there is only one installed.
Either remove and explicitly install matching versions or dedupe using your package manager.
The following conflicting packages were found:
	7.1.1	/home/dan/interlay/dev/polkabtc-js/node_modules/@polkadot/typegen/node_modules/@polkadot/util
	7.1.1	/home/dan/interlay/dev/polkabtc-js/node_modules/@polkadot/types/node_modules/@polkadot/util
@polkadot/util has multiple versions, ensure that there is only one installed.
Either remove and explicitly install matching versions or dedupe using your package manager.
The following conflicting packages were found:
	7.1.1	/home/dan/interlay/dev/polkabtc-js/node_modules/@polkadot/typegen/node_modules/@polkadot/util
	7.1.1	/home/dan/interlay/dev/polkabtc-js/node_modules/@polkadot/types/node_modules/@polkadot/util
	7.1.1	/home/dan/interlay/dev/polkabtc-js/node_modules/@polkadot/util-crypto/node_modules/@polkadot/util
@polkadot/util has multiple versions, ensure that there is only one installed.
Either remove and explicitly install matching versions or dedupe using your package manager.
The following conflicting packages were found:
	7.1.1	/home/dan/interlay/dev/polkabtc-js/node_modules/@polkadot/typegen/node_modules/@polkadot/util
	7.1.1	/home/dan/interlay/dev/polkabtc-js/node_modules/@polkadot/types/node_modules/@polkadot/util
	7.1.1	/home/dan/interlay/dev/polkabtc-js/node_modules/@polkadot/util-crypto/node_modules/@polkadot/util
	7.1.1	/home/dan/interlay/dev/polkabtc-js/node_modules/@polkadot/types-known/node_modules/@polkadot/util
```