### PR TITLE
chore: downgrade monetary-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interlay/interbtc",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "JavaScript library to interact with InterBTC",
   "main": "build/index.js",
   "typings": "build/index.d.ts",
@@ -23,7 +23,7 @@
     "@interlay/interbtc-api": "1.6.1",
     "@interlay/interbtc-index-client": "1.6.0",
     "@interlay/interbtc-types": "1.3.0",
-    "@interlay/monetary-js": "0.5.4"
+    "@interlay/monetary-js": "0.5.3"
   },
   "devDependencies": {
     "@types/node": "^14.6.4",


### PR DESCRIPTION
`monetary-js` v0.5.4 was breaking the build because interbtc-api uses 0.5.3